### PR TITLE
/users/:id/actions/change_password endpoint

### DIFF
--- a/lib/mithril_api/authorization/grant_type/authorization_code.ex
+++ b/lib/mithril_api/authorization/grant_type/authorization_code.ex
@@ -36,7 +36,7 @@ defmodule Mithril.Authorization.GrantType.AuthorizationCode do
   end
 
   defp create_access_token({:error, err, code}), do: {:error, err, code}
-  defp create_access_token({:ok, token, app}) do
+  defp create_access_token({:ok, token, _app}) do
     {:ok, refresh_token} = Mithril.TokenAPI.create_refresh_token(%{
       user_id: token.user_id,
       details: %{

--- a/lib/mithril_api/user_api/user.ex
+++ b/lib/mithril_api/user_api/user.ex
@@ -7,6 +7,7 @@ defmodule Mithril.UserAPI.User do
   schema "users" do
     field :email, :string
     field :password, :string
+    field :current_password, :string, virtual: true
     field :settings, :map, default: %{}
     field :priv_settings, :map, default: %{}
 

--- a/lib/mithril_api/user_api/user_api.ex
+++ b/lib/mithril_api/user_api/user_api.ex
@@ -63,7 +63,7 @@ defmodule Mithril.UserAPI do
       |> validate_changed(:password)
       |> validate_passwords_match(:password, :current_password)
 
-    if changeset.valid? == true do
+    if changeset.valid? do
       Repo.update(changeset)
     else
       changeset

--- a/lib/mithril_api/user_api/user_api.ex
+++ b/lib/mithril_api/user_api/user_api.ex
@@ -55,9 +55,28 @@ defmodule Mithril.UserAPI do
     user_changeset(user, %{})
   end
 
+  def change_user_password(%User{} = user, user_params) do
+    changeset =
+      user
+      |> user_changeset(user_params)
+      |> validate_required([:current_password])
+      |> validate_changed(:password)
+      |> validate_passwords_match(:password, :current_password)
+
+    if changeset.valid? == true do
+      Repo.update(changeset)
+    else
+      changeset
+    end
+  end
+
+  defp get_password_hash(password) do
+    Comeonin.Bcrypt.hashpwsalt(password)
+  end
+
   defp user_changeset(%User{} = user, attrs) do
     user
-    |> cast(attrs, [:email, :password, :settings])
+    |> cast(attrs, [:email, :password, :settings, :current_password])
     |> validate_required([:email, :password])
     |> unique_constraint(:email)
     |> put_password()
@@ -65,11 +84,34 @@ defmodule Mithril.UserAPI do
 
   defp put_password(changeset) do
     if password = get_change(changeset, :password) do
-      secured_password = Comeonin.Bcrypt.hashpwsalt(password)
-
-      put_change(changeset, :password, secured_password)
+      put_change(changeset, :password, get_password_hash(password))
     else
       changeset
+    end
+  end
+
+  defp validate_changed(changeset, field) do
+    case fetch_change(changeset, field) do
+      :error -> add_error(changeset, field, "is not changed", validation: :required)
+      {:ok, _change} -> changeset
+    end
+  end
+
+  defp validate_passwords_match(changeset, field1, field2) do
+    validate_change changeset, field1, :password, fn _, _new_value ->
+      %{data: data} = changeset
+      field1_hash = Map.get(data, field1)
+
+      with {:ok, value2} <- fetch_change(changeset, field2),
+           true <- Comeonin.Bcrypt.checkpw(value2, field1_hash) do
+        []
+      else
+        :error ->
+          []
+        false ->
+          [{field2,
+           {"#{to_string(field1)} does not match password in field #{to_string(field2)}", [validation: :password]}}]
+      end
     end
   end
 end

--- a/lib/mithril_api/user_api/user_api.ex
+++ b/lib/mithril_api/user_api/user_api.ex
@@ -63,11 +63,7 @@ defmodule Mithril.UserAPI do
       |> validate_changed(:password)
       |> validate_passwords_match(:password, :current_password)
 
-    if changeset.valid? do
-      Repo.update(changeset)
-    else
-      changeset
-    end
+    Repo.update(changeset)
   end
 
   defp get_password_hash(password) do

--- a/lib/mithril_api/web/controllers/user_controller.ex
+++ b/lib/mithril_api/web/controllers/user_controller.ex
@@ -42,4 +42,11 @@ defmodule Mithril.Web.UserController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  def change_password(conn, %{"user_id" => id, "user" => user_params}) do
+    user = UserAPI.get_user!(id)
+    with {:ok, %User{} = user} <- UserAPI.change_user_password(user, user_params) do
+      render(conn, "show.json", user: user)
+    end
+  end
 end

--- a/lib/mithril_api/web/router.ex
+++ b/lib/mithril_api/web/router.ex
@@ -32,7 +32,7 @@ defmodule Mithril.Web.Router do
       delete "/tokens", TokenController, :delete_by_user
       delete "/apps", AppController, :delete_by_user
 
-      put "/action/change_password", UserController, :change_password
+      put "/actions/change_password", UserController, :change_password
     end
 
     resources "/clients", ClientController, except: [:new, :edit] do

--- a/lib/mithril_api/web/router.ex
+++ b/lib/mithril_api/web/router.ex
@@ -31,6 +31,8 @@ defmodule Mithril.Web.Router do
       delete "/roles", UserRoleController, :delete_by_user, as: :role
       delete "/tokens", TokenController, :delete_by_user
       delete "/apps", AppController, :delete_by_user
+
+      put "/action/change_password", UserController, :change_password
     end
 
     resources "/clients", ClientController, except: [:new, :edit] do

--- a/lib/mithril_api/web/router.ex
+++ b/lib/mithril_api/web/router.ex
@@ -32,7 +32,7 @@ defmodule Mithril.Web.Router do
       delete "/tokens", TokenController, :delete_by_user
       delete "/apps", AppController, :delete_by_user
 
-      put "/actions/change_password", UserController, :change_password
+      patch "/actions/change_password", UserController, :change_password
     end
 
     resources "/clients", ClientController, except: [:new, :edit] do

--- a/test/web/controllers/user_controller_test.exs
+++ b/test/web/controllers/user_controller_test.exs
@@ -111,7 +111,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{"password" => "world", current_password: "hello"}}
-      conn = put conn, user_path(conn, :update, user) <> "/action/change_password", update_params
+      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert json_response(conn, 200)
 
       assert Comeonin.Bcrypt.checkpw("world", UserAPI.get_user(user.id).password)
@@ -121,7 +121,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{"password" => "world", current_password: "invalid"}}
-      conn = put conn, user_path(conn, :update, user) <> "/action/change_password", update_params
+      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert [%{"entry" => "$.current_password", "rules" => [%{"rule" => "password"}]}]
         = json_response(conn, 422)["error"]["invalid"]
     end
@@ -130,7 +130,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{"password" => "world"}}
-      conn = put conn, user_path(conn, :update, user) <> "/action/change_password", update_params
+      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert [%{"entry" => "$.current_password", "rules" => [%{"rule" => "required"}]}]
         = json_response(conn, 422)["error"]["invalid"]
     end
@@ -139,7 +139,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{current_password: "hello"}}
-      conn = put conn, user_path(conn, :update, user) <> "/action/change_password", update_params
+      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert [%{"entry" => "$.password", "rules" => [%{"rule" => "required"}]}]
         = json_response(conn, 422)["error"]["invalid"]
     end

--- a/test/web/controllers/user_controller_test.exs
+++ b/test/web/controllers/user_controller_test.exs
@@ -111,7 +111,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{"password" => "world", current_password: "hello"}}
-      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
+      conn = patch conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert json_response(conn, 200)
 
       assert Comeonin.Bcrypt.checkpw("world", UserAPI.get_user(user.id).password)
@@ -121,7 +121,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{"password" => "world", current_password: "invalid"}}
-      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
+      conn = patch conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert [%{"entry" => "$.current_password", "rules" => [%{"rule" => "password"}]}]
         = json_response(conn, 422)["error"]["invalid"]
     end
@@ -130,7 +130,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{"password" => "world"}}
-      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
+      conn = patch conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert [%{"entry" => "$.current_password", "rules" => [%{"rule" => "required"}]}]
         = json_response(conn, 422)["error"]["invalid"]
     end
@@ -139,7 +139,7 @@ defmodule Mithril.Web.UserControllerTest do
       user = fixture(:user, %{email: "1", password: "hello", settings: %{}})
 
       update_params = %{user: %{current_password: "hello"}}
-      conn = put conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
+      conn = patch conn, user_path(conn, :update, user) <> "/actions/change_password", update_params
       assert [%{"entry" => "$.password", "rules" => [%{"rule" => "required"}]}]
         = json_response(conn, 422)["error"]["invalid"]
     end


### PR DESCRIPTION
It accepts user params with additional field «current_password», and if
this field matches password hash - applies all changes to the User,
including new password.